### PR TITLE
Removed 3.9 support from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/ionite34/sized"
 keywords = ["generator", "iterator", "iter", "sizedgenerator"]
 
 [tool.poetry.dependencies]
-python = ">=3.8, <3.12"
+python = ">=3.9, <3.12"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.2"


### PR DESCRIPTION
- Removed 3.9 as not compatible due to `collections.abc` type subscripting